### PR TITLE
feat: allow dry-run flag

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -43,6 +43,7 @@ export const VIEWPORT_WIDTH = 1200;
 export const SCREENSHOT_FORMAT = 'png';
 export const SUPPORTED_FORMATS = ['pdf', 'png', 'epub'];
 export const PENDING_STATUS = 'pending';
+export const DONE_STATUS = 'done';
 export const EXPORT_TOPIC = `export-${STAGE}`;
 
 export const GRAASP_VIEWER = /https?:\/\/viewer\.(dev\.)?graasp\.eu/g;
@@ -51,7 +52,10 @@ export const GRAASP_CLOUD = /https?:\/\/cloud\.(dev\.)?graasp\.eu/g;
 export const AUTH_TYPE_ANONYMOUS = 'local-contextual-anonymous';
 export const AUTH_TYPE_USERNAME = 'local-contextual-username';
 export const AUTH_TYPE_PASSWORD = 'local-contextual-username-password';
-export const TIMEOUT = 60000;
+
+// the files page that download the generated file times out at 3 minutes
+// (180000ms), so ensure that this timeout is less than or equal than that one
+export const TIMEOUT = 180000;
 export const ELEMENTS_TIMEOUT = 3000;
 
 export const DEFAULT_LANGUAGE = 'en';
@@ -74,3 +78,57 @@ export const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Credentials': true,
 };
+
+// emulates the settings inside the chrome devtools panel
+// source: https://fdalvi.github.io/blog/2018-02-05-puppeteer-network-throttle/
+export const NETWORK_PRESETS = {
+  GPRS: {
+    offline: false,
+    downloadThroughput: (50 * 1024) / 8,
+    uploadThroughput: (20 * 1024) / 8,
+    latency: 500,
+  },
+  Regular2G: {
+    offline: false,
+    downloadThroughput: (250 * 1024) / 8,
+    uploadThroughput: (50 * 1024) / 8,
+    latency: 300,
+  },
+  Good2G: {
+    offline: false,
+    downloadThroughput: (450 * 1024) / 8,
+    uploadThroughput: (150 * 1024) / 8,
+    latency: 150,
+  },
+  Regular3G: {
+    offline: false,
+    downloadThroughput: (750 * 1024) / 8,
+    uploadThroughput: (250 * 1024) / 8,
+    latency: 100,
+  },
+  Good3G: {
+    offline: false,
+    downloadThroughput: (1.5 * 1024 * 1024) / 8,
+    uploadThroughput: (750 * 1024) / 8,
+    latency: 40,
+  },
+  Regular4G: {
+    offline: false,
+    downloadThroughput: (4 * 1024 * 1024) / 8,
+    uploadThroughput: (3 * 1024 * 1024) / 8,
+    latency: 20,
+  },
+  DSL: {
+    offline: false,
+    downloadThroughput: (2 * 1024 * 1024) / 8,
+    uploadThroughput: (1 * 1024 * 1024) / 8,
+    latency: 5,
+  },
+  WiFi: {
+    offline: false,
+    downloadThroughput: (30 * 1024 * 1024) / 8,
+    uploadThroughput: (15 * 1024 * 1024) / 8,
+    latency: 2,
+  },
+};
+export const DEFAULT_NETWORK_PRESET = 'Regular3G';


### PR DESCRIPTION
Allow making a dry run of the export process to signal how heavy a
learning space can be.

closes #61