### PR TITLE
fix: fix parallel cover images, add prettier:write cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "domain:delete:prod": "serverless delete_domain --stage prod",
     "deploy:dev": "serverless deploy --stage dev",
     "deploy:prod": "serverless deploy --stage prod",
-    "prettier": "prettier --fix 'src/**/*.js'",
+    "prettier:write": "prettier --write 'src/**/*.js'",
     "prettier:check": "prettier --check 'src/**/*.js'",
     "release": "git add CHANGELOG.md && standard-version -a",
     "hooks:uninstall": "node node_modules/husky/husky.js uninstall",

--- a/src/services/cover.js
+++ b/src/services/cover.js
@@ -1,3 +1,4 @@
+/* eslint no-param-reassign: ["error", { "props": false }] */
 import { createCanvas, loadImage } from 'canvas';
 import fs from 'fs';
 import dateFormat from 'dateformat';
@@ -7,8 +8,6 @@ import { BACKGROUND_COLOR, FONT, FONT_COLOR } from '../config';
 
 const { toRoman } = RomanNumerals;
 
-const canvas = createCanvas(600, 800);
-const context = canvas.getContext('2d');
 const marginLeft = 50;
 const marginTop = 100;
 
@@ -51,7 +50,7 @@ const prepareInfoTexts = metadata => {
   return lines;
 };
 
-const writeSecondaryTitle = (heightPadding, title) => {
+const writeSecondaryTitle = (context, heightPadding, title) => {
   context.font = `${secondaryTitleFontSize}px ${FONT}`;
   const y =
     imageMargin +
@@ -62,7 +61,7 @@ const writeSecondaryTitle = (heightPadding, title) => {
   context.fillText(title, marginLeft, y);
 };
 
-const writeMetadata = (heightPadding, metadata) => {
+const writeMetadata = (context, heightPadding, metadata) => {
   const lines = prepareInfoTexts(metadata);
   lines.forEach((line, index) => {
     context.font = `${line.style} ${fontSize}px ${FONT}`;
@@ -84,6 +83,9 @@ const coverImage = async (
   metadata,
   path
 ) => {
+  const canvas = createCanvas(600, 800);
+  const context = canvas.getContext('2d');
+
   // background
   context.fillStyle = BACKGROUND_COLOR;
   context.fillRect(0, 0, canvas.width, canvas.height);
@@ -112,9 +114,9 @@ const coverImage = async (
 
   // ils metadata
   if (sectionNumber) {
-    writeSecondaryTitle(headerHeight, title);
+    writeSecondaryTitle(context, headerHeight, title);
   } else {
-    writeMetadata(headerHeight, metadata);
+    writeMetadata(context, headerHeight, metadata);
   }
 
   // Image background

--- a/src/services/export.test.html
+++ b/src/services/export.test.html
@@ -11,26 +11,18 @@
 
   <body>
     <base id="base-empty" href="" />
-    <base id="base-https-slash" href="https://example.com/" />
-    <base id="base-https-noslash" href="https://example.com" />
-    <base id="base-http-slash" href="http://example.com/" />
-    <base id="base-http-noslash" href="http://example.com" />
-    <base id="base-doubleslash-noslash" href="//example.com" />
-    <base id="base-doubleslash-slash" href="//example.com/" />
+    <base id="base-https-slash" href="https://graasp.eu/" />
+    <base id="base-https-noslash" href="https://graasp.eu/" />
+    <base id="base-http-slash" href="http://graasp.eu/" />
+    <base id="base-http-noslash" href="http://graasp.eu" />
+    <base id="base-doubleslash-noslash" href="//graasp.eu" />
+    <base id="base-doubleslash-slash" href="//graasp.eu/" />
 
-    <iframe
-      id="iframe-https"
-      src="https://example.com/"
-      frameborder="0"
-    ></iframe>
-    <iframe id="iframe-http" src="http://example.com/" frameborder="0"></iframe>
-    <iframe id="iframe-point" src="./example.com/" frameborder="0"></iframe>
-    <iframe
-      id="iframe-doubleslash"
-      src="//example.com"
-      frameborder="0"
-    ></iframe>
-    <iframe id="iframe-plain" src="example.com" frameborder="0"></iframe>
+    <iframe id="iframe-https" src="https://graasp.eu/" frameborder="0"></iframe>
+    <iframe id="iframe-http" src="http://graasp.eu/" frameborder="0"></iframe>
+    <iframe id="iframe-point" src="./graasp.eu/" frameborder="0"></iframe>
+    <iframe id="iframe-doubleslash" src="//graasp.eu" frameborder="0"></iframe>
+    <iframe id="iframe-plain" src="graasp.eu" frameborder="0"></iframe>
     <iframe id="iframe-empty" src="" frameborder="0"></iframe>
 
     <div></div>

--- a/src/services/exportHandlers.test.js
+++ b/src/services/exportHandlers.test.js
@@ -356,7 +356,7 @@ describe('handleObjects', () => {
 
 describe('handleOfflineLabs', () => {
   const lang = DEFAULT_LANGUAGE;
-  const baseUrl = 'https://example.com/';
+  const baseUrl = 'https://graasp.eu/';
 
   beforeAll(async () => {
     await initPuppeteerWithMode();

--- a/src/services/exportUtils.test.js
+++ b/src/services/exportUtils.test.js
@@ -74,33 +74,33 @@ describe('makeElementsLinkAbsolute', () => {
   it('if attrName is empty, src url stays unchanged', async () => {
     const iframe = await page.$('#iframe-https');
 
-    await makeElementsLinkAbsolute([iframe], '', 'https://example.com/', page);
+    await makeElementsLinkAbsolute([iframe], '', 'https://graasp.eu/', page);
     const url = await getSrcValue(iframe);
 
-    expect(url).toMatch('https://example.com/');
+    expect(url).toMatch('https://graasp.eu/');
   });
 
   it('if selector is null, no error is thrown', async () => {
     const el = await page.$('no-selector');
 
     expect(
-      makeElementsLinkAbsolute([el], 'src', 'https://example.com/', page)
+      makeElementsLinkAbsolute([el], 'src', 'https://graasp.eu/', page)
     ).resolves.not.toThrow();
   });
 
   it('https:// url stays unchanged ', async () => {
     await evaluateMakeElementLinkAbsolute(
       '#iframe-https',
-      'https://example.com/',
-      `https://example.com`
+      'https://graasp.eu/',
+      `https://graasp.eu/`
     );
   });
 
   it('http:// url stays unchanged ', async () => {
     await evaluateMakeElementLinkAbsolute(
       '#iframe-http',
-      'https://example.com/',
-      `http://example.com`
+      'https://graasp.eu/',
+      `http://graasp.eu/`
     );
   });
 
@@ -108,7 +108,7 @@ describe('makeElementsLinkAbsolute', () => {
     const iframe = await page.$('#iframe-https');
 
     expect(
-      makeElementsLinkAbsolute([iframe], 'src', 'https:/example.com', page)
+      makeElementsLinkAbsolute([iframe], 'src', 'https:/graasp.eu', page)
     ).rejects.toThrow();
   });
 
@@ -116,31 +116,31 @@ describe('makeElementsLinkAbsolute', () => {
     const iframe = await page.$('#iframe-https');
 
     expect(
-      makeElementsLinkAbsolute([iframe], 'src', 'example.com/', page)
+      makeElementsLinkAbsolute([iframe], 'src', 'graasp.eu/', page)
     ).rejects.toThrow();
   });
 
-  it('//example.com becomes https://example.com', async () => {
+  it('//graasp.eu becomes https://graasp.eu', async () => {
     await evaluateMakeElementLinkAbsolute(
       '#iframe-doubleslash',
-      'https://example.com/',
-      `https://example.com`
+      'https://graasp.eu/',
+      `https://graasp.eu`
     );
   });
 
-  it('https://example.com/ + example.com becomes https://example.com/example.com', async () => {
+  it('https://graasp.eu/ + graasp.eu becomes https://graasp.eu/graasp.eu', async () => {
     await evaluateMakeElementLinkAbsolute(
       '#iframe-plain',
-      'https://example.com/',
-      `https://example.com/example.com`
+      'https://graasp.eu/',
+      `https://graasp.eu/graasp.eu`
     );
   });
 
-  it('https://example.com/ + ./example.com becomes https://example.com/example.com', async () => {
+  it('https://graasp.eu/ + ./graasp.eu becomes https://graasp.eu/graasp.eu', async () => {
     await evaluateMakeElementLinkAbsolute(
       '#iframe-point',
-      'https://example.com/',
-      `https://example.com/example.com`
+      'https://graasp.eu/',
+      `https://graasp.eu/graasp.eu`
     );
   });
 });
@@ -168,45 +168,42 @@ describe('retrieveBaseUrl', () => {
   });
 
   it('https://.../ base url returns the same https://.../', async () => {
-    await evaluateRetrieveBaseUrl('#base-https-slash', 'https://example.com/');
+    await evaluateRetrieveBaseUrl('#base-https-slash', 'https://graasp.eu/');
   });
 
   it('https://... base url returns https://.../', async () => {
-    await evaluateRetrieveBaseUrl(
-      '#base-https-noslash',
-      'https://example.com/'
-    );
+    await evaluateRetrieveBaseUrl('#base-https-noslash', 'https://graasp.eu/');
   });
 
   it('http://.../ base url returns the same http://.../', async () => {
-    await evaluateRetrieveBaseUrl('#base-http-slash', 'http://example.com/');
+    await evaluateRetrieveBaseUrl('#base-http-slash', 'http://graasp.eu/');
   });
 
   it('http://... base url returns http://.../', async () => {
-    await evaluateRetrieveBaseUrl('#base-http-noslash', 'http://example.com/');
+    await evaluateRetrieveBaseUrl('#base-http-noslash', 'http://graasp.eu/');
   });
 
   it('//.../ base url returns https://.../', async () => {
     await evaluateRetrieveBaseUrl(
       '#base-doubleslash-slash',
-      'https://example.com/'
+      'https://graasp.eu/'
     );
   });
 
   it('//... base url returns https://.../', async () => {
     await evaluateRetrieveBaseUrl(
       '#base-doubleslash-noslash',
-      'https://example.com/'
+      'https://graasp.eu/'
     );
   });
 });
 
 describe('getDownloadUrl', () => {
-  const metaTags = `<meta name="download" value="https://example.com/"></meta>
-    <meta name="download" language="fr" value="https://example.com/fr"></meta>`;
+  const metaTags = `<meta name="download" value="https://graasp.eu/"></meta>
+    <meta name="download" language="fr" value="https://graasp.eu/fr"></meta>`;
 
   const metaTagsWithEn = `${metaTags}<meta name="download" language="${DEFAULT_LANGUAGE}" 
-    value="https://example.com/${DEFAULT_LANGUAGE}"></meta>`;
+    value="https://graasp.eu/${DEFAULT_LANGUAGE}"></meta>`;
 
   it('content="" returns null', async () => {
     const url = await getDownloadUrl('', DEFAULT_LANGUAGE);
@@ -220,7 +217,7 @@ describe('getDownloadUrl', () => {
 
   it('language="" returns default language content if exist', async () => {
     const url = await getDownloadUrl(metaTagsWithEn, '');
-    expect(url).toMatch(`https://example.com/${DEFAULT_LANGUAGE}`);
+    expect(url).toMatch(`https://graasp.eu/${DEFAULT_LANGUAGE}`);
   });
 
   it('language="" returns null if en doesnt exist', async () => {
@@ -230,7 +227,7 @@ describe('getDownloadUrl', () => {
 
   it('default language returns corresponding url if exists', async () => {
     const url = await getDownloadUrl(metaTagsWithEn, DEFAULT_LANGUAGE);
-    expect(url).toMatch('https://example.com/en');
+    expect(url).toMatch('https://graasp.eu/en');
   });
 
   it('default language returns null if doesnt exists', async () => {
@@ -240,7 +237,7 @@ describe('getDownloadUrl', () => {
 
   it('lang=es returns default language url', async () => {
     const url = await getDownloadUrl(metaTagsWithEn, 'es');
-    expect(url).toMatch(`https://example.com/${DEFAULT_LANGUAGE}`);
+    expect(url).toMatch(`https://graasp.eu/${DEFAULT_LANGUAGE}`);
   });
 });
 


### PR DESCRIPTION
This commit creates a canvas and context for each space, avoiding to share these between spaces and thus resulting in incorrect cover images.
Tests were also changed with a working link (graasp.eu instead of example.com)